### PR TITLE
Move focus on key to util class & add force focus option

### DIFF
--- a/projects/angular-components/src/lib/utils/focus-on-key.util.ts
+++ b/projects/angular-components/src/lib/utils/focus-on-key.util.ts
@@ -1,0 +1,39 @@
+export type FocusOnKeyConfig = {
+  key: string;
+  ctrl: boolean;
+  shift: boolean;
+  force: boolean;
+};
+
+export class FocusOnKeyUtil {
+  constructor(
+    private config: FocusOnKeyConfig = { key: 'k', ctrl: true, shift: false, force: false },
+    private focusElement?: HTMLElement,
+  ) {}
+
+  setFocusElement(focusElement: HTMLElement): void {
+    this.focusElement = focusElement;
+  }
+
+  updateConfig(config: Partial<FocusOnKeyConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  enable(): void {
+    if (!this.focusElement) console.warn('No focus element set');
+    window.addEventListener(this.config.force ? 'keydown' : 'keyup', this._onKeyEvent.bind(this));
+  }
+
+  disable(): void {
+    window.removeEventListener('keydown', this._onKeyEvent);
+    window.removeEventListener('keyup', this._onKeyEvent);
+  }
+
+  private _onKeyEvent(event: KeyboardEvent): void {
+    if (!this.focusElement) return;
+    if (event.key === this.config.key) {
+      this.focusElement.focus();
+      event.preventDefault();
+    }
+  }
+}

--- a/projects/angular-components/src/public_api.ts
+++ b/projects/angular-components/src/public_api.ts
@@ -12,3 +12,4 @@ export * from './lib/datatable/dt-content.directive';
 
 // helper classes
 export * from './lib/icons/icon-base';
+export * from './lib/utils/focus-on-key.util';

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -24,7 +24,7 @@
   <li>
     <h2>Search</h2>
     <div class="components">
-      <ff-search [(ngModel)]="searchText" style="width: 100%"></ff-search>
+      <ff-search [(ngModel)]="searchText" style="width: 100%" forceFocus></ff-search>
       <div class="separator">
         <ff-search placeholder="Test the focus key" focusKey="=" style="width: 100%"></ff-search>
         <ff-search placeholder="Disabled" style="width: 100%" disabled></ff-search>


### PR DESCRIPTION
Added force focus option since `keyup` event while being a nicer one to use might not get triggered if the browser uses that same key for something. Force focus sets it so `keydown` is used which is more invasive to the user experience but will run before the browser checks for the key event